### PR TITLE
Connecting to Wireguard VPN through Linux's Network Manager

### DIFF
--- a/CONNECTING-TO-WG-VPN.md
+++ b/CONNECTING-TO-WG-VPN.md
@@ -1,0 +1,35 @@
+# [Linux] Connecting to Wireguard VPN using Network Manager
+
+## 1. Install Wireguard plugin
+As a prerequisite, you should have Wireguard plugin for Network Manager installed. See [here](https://github.com/max-moser/network-manager-wireguard/). Some linux distributions provide pre-built packages:
+
+###  Arch
+
+From the Arch User Repository, you can install `networkmanager-wireguard-git`.
+
+## 2. Retrieve your Wireguard configuration
+
+At the end of wireguard configuration, a `conf` file should have been created to allow a client to connect to the VPN. Retrieve your file and copy it to the device you want to connect from.
+
+## 3. Tweaking the config file
+
+The generated file is formatted in a way that is unreadable by Network Manager.
+
+You should open the config file and make sure that fields holding 2 IP address (IPv4 and IPv6), that are separated by a comma, should have a space after the comma. For example `Address = 10.66.66.3/24,fd42:42:42::3/64` should be changed to `Address = 10.66.66.3/24, fd42:42:42::3/64` (note the space after the comma).
+
+Fields that might be affected by this issue are **(non-exhaustive list)**:
+
+  - Address
+  - DNS
+  - AllowedIPs
+
+Make sure to add an extra space after the comma, if needed.
+
+## 4. Importing the configuration
+
+  1. Right click on Network Manager applet
+  2. Select `Modify connections`
+  3. At the bottom left, click on the `+` symbol
+  4. From the dropdown menu, select `Import saved VPN configuration` and confirm
+  5. Select the configuration and confirm.
+  6. You are free to change the name of the VPN configuration if you want. Once done, click `Save` and you should see the VPN connection pop up in the list.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will:
 
 3. Make sure your router or firewall is forwarding incoming UDP packets on Port 51515 to the Ubuntu 20.04 Minimal LTS Server, that you ran the **setup.sh** script on.
 4. Create another VPN Client Profile by running `./setup.sh` again, you can create 253 profiles without modifying the script.
-
+5. Now that the setup is over, you can look into [Connecting to Wireguard VPN](./CONNECTING-TO-WG-VPN.md)
 ---
 
 # Detailed Guides
@@ -67,6 +67,7 @@ This simple 2 step process will get you up and running:
 - **STEP 1** [Google Cloud Login, Account Creation, & Server Provisioning](./GOOGLE-CLOUD.md)
 - **STEP 2** [Software Installation & Configuration](./CONFIGURATION.md)
 
+To connect and use the VPN, take a look at [Connecting to Wireguard VPN](./CONNECTING-TO-WG-VPN.md)
 The technical merits of major choices in this guide are outlined in [REASONS.md](./REASONS.md).
 
 ---


### PR DESCRIPTION
As per title.

**Some notes:**

- Since I have followed [Option A](https://github.com/rajannpatel/Pi-Hole-on-Google-Compute-Engine-Free-Tier-with-Full-Tunnel-and-Split-Tunnel-Wireguard-VPN-Configs#option-a--set-up-a-pi-hole-ad-blocking-vpn-server-with-a-static-anycast-ip-on-google-clouds-always-free-usage-tier) it might not be 100% fitting for Option B. Thus, at the end of [Option B paragraph](https://github.com/rajannpatel/Pi-Hole-on-Google-Compute-Engine-Free-Tier-with-Full-Tunnel-and-Split-Tunnel-Wireguard-VPN-Configs#option-b--set-up-a-pi-hole-ad-blocking-vpn-server-behind-your-router-at-home) I haven't added anything.
- Steps described in point 4, might not have the correct indication for buttons and whatnot. My network manager is not in English, so translation might not match what you see, but still, it should give a good indication.
- I couldn't not understand if there is an existing package for Ubuntu in its repo. Consider creating an issue to further document the steps for Ubuntu