### PR TITLE
Advise a local DNS record for accessing admin console

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -40,7 +40,7 @@ bash ./setup.sh
 
 It will automatically increment the IP Addresses for each new client profile, continue accepting all the default values the script provides. The option to edit values is provided for advanced users with edge case requirements.
 
-6. [Configure the Wireguard VPN Client on your device](./CONNECTING-TO-WG-VPN.md). Once your device is connected via Wireguard, all your DNS requests will flow through Pi-Hole. Your device will be identified by its IPv6 address in Pi-Hole's admin interface, which will be accessible at both `http://[fd42:42:42::1]/admin` and `http://10.66.66.1/admin`. The default configuration (which is the recommended configuration) for all VPN profiles is Split Tunnel. If you wish to route all your traffic through the VPN (Full Tunnel), edit the **Allowed IPs** on your Client Profile on your device to read `0.0.0.0/0, ::/0`.
+6. [Configure the Wireguard VPN Client on your device](./CONNECTING-TO-WG-VPN.md). Once your device is connected via Wireguard, all your DNS requests will flow through Pi-Hole. Your device will be identified by its IPv6 address in Pi-Hole's admin interface, which will be accessible at both `http://[fd42:42:42::1]/admin` and `http://10.66.66.1/admin`. If you want to be able to access the admin consle from pi.hole/admin, as described in the Pi-Hole docs, add a [local DNS record](http://pi.hole/admin/dns_records.php) in pointing pi.hole to `10.66.66.1`. The default configuration (which is the recommended configuration) for all VPN profiles is Split Tunnel. If you wish to route all your traffic through the VPN (Full Tunnel), edit the **Allowed IPs** on your Client Profile on your device to read `0.0.0.0/0, ::/0`.
 
 ### NOTE: Google Cloud Free Tier limits for Google Compute Engine
 


### PR DESCRIPTION
The IP address for pi.hole in /etc/pihole/local.list is the internal IP of the VM instance, not of Wireguard, which is what is needed.

Fixes #47