### PR TITLE
Removed hard coded IPs from addClient function

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -276,8 +276,13 @@ if [[ $OS =~ (fedora|centos) ]] && [[ $WG_RUNNING -ne 0 ]]; then
 fi
 
 # install pihole if it has not been installed
-if ! type "pihole" > /dev/null; then
+if ! type "pihole" &> /dev/null; then
 	curl -sSL https://install.pi-hole.net | bash
+	ec=$?
+	if [ ${ec} -nq 0 ]; then
+		printf "\n\e[1mERROR \e[0m- Failed to install PiHole!\n"
+		exit ${ec}
+	fi
 fi
 
 # use client configurations to determine if this is the first run, and apply preferred initial configurations

--- a/setup.sh
+++ b/setup.sh
@@ -217,6 +217,10 @@ fi
 mkdir /etc/wireguard >/dev/null 2>&1
 
 chmod 600 -R /etc/wireguard/
+# On CentOS and Fedore wg-quick service won't find the config without execution rights on the folder
+if [[ $OS =~ (fedora|centos) ]]; then
+	chmod 700 /etc/wireguard
+fi
 
 SERVER_PRIV_KEY=$(wg genkey)
 SERVER_PUB_KEY=$(echo "$SERVER_PRIV_KEY" | wg pubkey)
@@ -279,7 +283,7 @@ fi
 if ! type "pihole" &> /dev/null; then
 	curl -sSL https://install.pi-hole.net | bash
 	ec=$?
-	if [ ${ec} -nq 0 ]; then
+	if [ $ec -ne 0 ]; then
 		printf "\n\e[1mERROR \e[0m- Failed to install PiHole!\n"
 		exit ${ec}
 	fi


### PR DESCRIPTION
IPs were hard coded in addClient function which prevented users from changing the default subnets.

The script does tell the user not to change the defaults, but changing IPs can be useful for advanced users. Ending up with client configs with wrong IPs is quite inconvenient.
So I have changed the addClient function to use the correct subnets from the params file saved during setup.

Also changed IPv4 detection when dig is not available and fixed some small issues which came up during testing the changes.

Code has been tested on Ubuntu, Debian, CentOS and Fedora (the latest versions available on google cloud)