### PR TITLE
Increase boot disk size within free tier limits from 10GB -> 30GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This guide assumes you are running the following commands in a Linux environment
         --machine-type=e2-micro \
         --address=pihole-external-ip \
         --tags=wireguard \
-        --boot-disk-size=10 \
+        --boot-disk-size=30 \
         --image-family=ubuntu-2404-lts-amd64 \
         --image-project=ubuntu-os-cloud \
         --metadata-from-file=user-data=cloud-init.yaml


### PR DESCRIPTION
https://docs.cloud.google.com/free/docs/free-cloud-features#compute states that free tier GCE instances can have 30 GB disks.